### PR TITLE
Fix leaderboard rendering for esbuild parsing

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,19 @@
+{
+  "name": "AlgorithmGuessr Codespace",
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+  "features": {
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "20"
+    }
+  },
+  "postCreateCommand": "npm install",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "dbaeumer.vscode-eslint",
+        "esbenp.prettier-vscode",
+        "github.vscode-github-actions"
+      ]
+    }
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+node_modules
+.dist
+.dist*
+.DS_Store
+wrangler.toml.local
+.env
+
+# Build outputs
+/dist

--- a/README.md
+++ b/README.md
@@ -1,2 +1,103 @@
 # AlgorithmGuessr
-这是一个基于Cloudflare Worker的项目，用户可以指定一个难度范围，系统会在CodeForces平台上这个难度范围中随机找一道题，并且在VJudge平台中获得这个题面和难度和题目标签。系统提供选择框，用户需要通过自己的判断来判断这道题的算法标签，系统会将用户的选择如果是对的，就涂成绿色，如果错了，就涂成红色的。此外，这个系统还有用户系统，可以登录与注册，并且每个用户有一个评分，每次答对一个算法标签就+1分，答错一个就-1分。管理员可以封禁与解封用户，也可以开放注册通道，也可以后台注册用户
+
+AlgorithmGuessr 是一个部署在 Cloudflare Workers 上的互动练习平台。用户可以在指定的 Codeforces 难度区间内随机抽取题目，通过阅读题面判断题目的算法标签。当用户提交答案后，系统会给出正误反馈并实时更新积分，管理员还可以进行用户管理与注册控制。
+
+## 功能概览
+
+- **题目抽取**：从 Codeforces 题库中按指定难度随机抽题，并尝试从 VJudge 获取题面、标签及难度等信息，无法获取时自动回退到原题链接。
+- **算法标签挑战**：内置常见算法标签候选项。用户多选后提交，系统校验是否完全匹配题目标签，答对加分、答错扣分。
+- **用户系统**：
+  - 用户注册 / 登录（支持首个用户自动成为管理员）。
+  - JWT 鉴权，支持持久化登录。
+  - 个人积分展示与排行榜。
+- **管理员能力**：
+  - 封禁 / 解封用户。
+  - 后台创建用户。
+  - 开启 / 关闭公开注册入口。
+  - 查看全部用户列表及状态。
+
+## 项目结构
+
+```
+.
+├── package.json          # 项目依赖与脚本
+├── schema.sql            # D1 数据库初始化脚本
+├── src
+│   ├── ui
+│   │   └── index.ts      # 渲染前端界面的模板字符串
+│   └── worker.ts         # Cloudflare Worker 主程序
+├── tsconfig.json
+└── wrangler.toml         # Wrangler 配置
+```
+
+## 本地开发
+
+1. 安装依赖：
+   ```bash
+   npm install
+   ```
+2. 根据需要修改 `wrangler.toml`，填入实际的 KV、D1 等绑定信息。
+3. 初始化数据库（首次运行）：
+   ```bash
+   wrangler d1 execute algorithm_guessr_db --file=./schema.sql
+   ```
+4. 启动本地开发环境：
+   ```bash
+   npm run dev
+   ```
+
+## 在 GitHub Codespaces 中快速体验
+
+1. 点击仓库页面上的 **Code → Create codespace on main**，等待环境自动构建。等待10分钟左右
+2. Codespace 会基于 `.devcontainer/devcontainer.json` 自动安装 Node.js 20 与项目依赖。
+3. 首次启动后在终端执行数据库初始化：
+   ```bash
+   wrangler d1 execute algorithm_guessr_db --file=./schema.sql
+   ```
+4. 运行开发服务器：
+   ```bash
+   npm run dev -- --remote
+   ```
+   > Codespaces 运行在远端环境，使用 `--remote` 选项以便通过公网 URL 访问。
+
+## 部署（全程使用 Wrangler CLI）
+
+1. 登录 Cloudflare 账号：
+   ```bash
+   wrangler login
+   ```
+2. 创建并记录资源标识：
+   ```bash
+   wrangler kv namespace create PROBLEM_CACHE
+   wrangler kv namespace create PROBLEM_CACHE --preview
+   wrangler d1 create algorithm_guessr_db
+   ```
+   > 命令执行后会输出 `id`、`preview_id` 与 `database_id`，请将它们填写到 `wrangler.toml` 中对应的位置。
+3. 注入私密配置：
+   ```bash
+   wrangler secret put JWT_SECRET
+   ```
+4. 初始化数据库 Schema：
+   ```bash
+   wrangler d1 execute algorithm_guessr_db --file=./schema.sql
+   ```
+5. 部署到 Cloudflare Workers：
+   ```bash
+   wrangler deploy
+   ```
+
+## 使用说明
+
+- 第一次部署后，首个注册的账户会自动拥有管理员权限，可用于配置系统。
+- 若关闭了公开注册，普通用户无法通过自助注册入口，只能由管理员在后台创建。
+- 题面与标签依赖第三方接口，若无法获取，会提示用户前往 Codeforces 原题阅读。
+
+## 安全提示
+
+- 项目默认使用 SHA-256 + 随机盐进行密码哈希，建议在生产环境下结合 HTTPS 与 Cloudflare Zero Trust 等额外防护。
+- `JWT_SECRET` 必须妥善保管，定期更换，并确保不同环境使用不同的密钥。
+- 请在 Cloudflare 仪表盘中配置合理的速率限制，避免被恶意刷分。
+
+## 许可证
+
+本项目采用 [MIT License](./LICENSE)。

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "algorithm-guessr",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy",
+    "d1:migrate": "wrangler d1 migrations apply algorithm_guessr_db"
+  },
+  "dependencies": {
+    "itty-router": "^4.0.23"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20240512.0",
+    "typescript": "^5.4.5",
+    "wrangler": "^3.56.0"
+  }
+}

--- a/schema.sql
+++ b/schema.sql
@@ -1,0 +1,29 @@
+CREATE TABLE IF NOT EXISTS users (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  username TEXT NOT NULL UNIQUE,
+  password_hash TEXT NOT NULL,
+  salt TEXT NOT NULL,
+  role TEXT NOT NULL DEFAULT 'user',
+  is_banned INTEGER NOT NULL DEFAULT 0,
+  score INTEGER NOT NULL DEFAULT 0,
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS settings (
+  key TEXT PRIMARY KEY,
+  value TEXT NOT NULL
+);
+
+INSERT OR IGNORE INTO settings (key, value) VALUES ('registration_open', 'true');
+
+CREATE TABLE IF NOT EXISTS problem_attempts (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  user_id INTEGER NOT NULL,
+  problem_id TEXT NOT NULL,
+  correct INTEGER NOT NULL,
+  selected_tags TEXT NOT NULL,
+  correct_tags TEXT NOT NULL,
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (user_id) REFERENCES users(id)
+);

--- a/src/ui/index.ts
+++ b/src/ui/index.ts
@@ -1,0 +1,697 @@
+export function renderApp(): string {
+  return `<!DOCTYPE html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Algorithm Guessr</title>
+    <style>
+      :root {
+        color-scheme: light dark;
+        font-family: "Inter", "SF Pro Display", "Segoe UI", sans-serif;
+      }
+      body {
+        margin: 0;
+        padding: 0;
+        background: radial-gradient(circle at top, #eef2ff, #f8fafc);
+        min-height: 100vh;
+        display: flex;
+        justify-content: center;
+        align-items: flex-start;
+        color: #0f172a;
+      }
+      .page {
+        width: min(1100px, 95vw);
+        margin: 3rem auto;
+        background: rgba(255, 255, 255, 0.85);
+        border-radius: 24px;
+        box-shadow: 0 20px 45px rgba(15, 23, 42, 0.15);
+        overflow: hidden;
+        backdrop-filter: blur(12px);
+        border: 1px solid rgba(148, 163, 184, 0.25);
+      }
+      header {
+        padding: 2.5rem 3rem 2rem;
+        background: linear-gradient(135deg, rgba(79, 70, 229, 0.95), rgba(14, 116, 144, 0.95));
+        color: white;
+      }
+      header h1 {
+        margin: 0 0 0.5rem;
+        font-size: 2.4rem;
+        letter-spacing: -0.03em;
+      }
+      header p {
+        margin: 0;
+        opacity: 0.8;
+      }
+      main {
+        padding: 2.5rem 3rem 3rem;
+        display: grid;
+        gap: 2.5rem;
+      }
+      section {
+        background: rgba(248, 250, 252, 0.9);
+        padding: 2rem;
+        border-radius: 20px;
+        border: 1px solid rgba(148, 163, 184, 0.2);
+      }
+      h2 {
+        margin-top: 0;
+        font-size: 1.4rem;
+        color: #1e293b;
+      }
+      form {
+        display: grid;
+        gap: 1rem;
+      }
+      label {
+        display: grid;
+        gap: 0.35rem;
+        font-size: 0.95rem;
+      }
+      input,
+      select,
+      button,
+      textarea {
+        font: inherit;
+      }
+      input,
+      select,
+      textarea {
+        padding: 0.75rem 1rem;
+        border-radius: 12px;
+        border: 1px solid rgba(148, 163, 184, 0.35);
+        background: white;
+        transition: border 150ms ease, box-shadow 150ms ease;
+      }
+      input:focus,
+      select:focus,
+      textarea:focus {
+        outline: none;
+        border-color: rgba(79, 70, 229, 0.6);
+        box-shadow: 0 0 0 4px rgba(79, 70, 229, 0.15);
+      }
+      button {
+        padding: 0.85rem 1.4rem;
+        border-radius: 14px;
+        border: none;
+        background: linear-gradient(135deg, #4f46e5, #0ea5e9);
+        color: white;
+        font-weight: 600;
+        cursor: pointer;
+        transition: transform 150ms ease, box-shadow 150ms ease, opacity 150ms ease;
+        justify-self: start;
+      }
+      button.secondary {
+        background: rgba(15, 23, 42, 0.05);
+        color: #0f172a;
+      }
+      button:hover {
+        transform: translateY(-1px);
+        box-shadow: 0 12px 25px rgba(79, 70, 229, 0.25);
+      }
+      button:disabled {
+        opacity: 0.5;
+        cursor: not-allowed;
+        transform: none;
+        box-shadow: none;
+      }
+      .grid-two {
+        display: grid;
+        gap: 1rem;
+        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      }
+      .problem-card {
+        display: grid;
+        gap: 1.25rem;
+      }
+      .problem-card header {
+        padding: 0;
+        background: none;
+        color: inherit;
+      }
+      .problem-meta {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.75rem;
+        font-size: 0.9rem;
+        color: rgba(15, 23, 42, 0.65);
+      }
+      .problem-statement {
+        background: white;
+        border-radius: 16px;
+        padding: 1.5rem;
+        border: 1px solid rgba(148, 163, 184, 0.25);
+        max-height: 420px;
+        overflow: auto;
+      }
+      .tag-options {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.75rem;
+      }
+      .tag-option {
+        padding: 0.5rem 1rem;
+        border-radius: 999px;
+        border: 1px solid rgba(148, 163, 184, 0.4);
+        background: white;
+        cursor: pointer;
+        transition: background 150ms ease, color 150ms ease, border 150ms ease, transform 150ms ease;
+      }
+      .tag-option.selected {
+        background: rgba(79, 70, 229, 0.12);
+        border-color: rgba(79, 70, 229, 0.6);
+        color: #312e81;
+        transform: translateY(-1px);
+      }
+      .tag-option.correct {
+        background: rgba(34, 197, 94, 0.15);
+        border-color: rgba(34, 197, 94, 0.6);
+        color: #166534;
+      }
+      .tag-option.incorrect {
+        background: rgba(239, 68, 68, 0.15);
+        border-color: rgba(239, 68, 68, 0.6);
+        color: #991b1b;
+      }
+      .message {
+        font-weight: 600;
+        padding: 0.75rem 1rem;
+        border-radius: 12px;
+        background: rgba(79, 70, 229, 0.08);
+        border: 1px solid rgba(79, 70, 229, 0.2);
+        color: #3730a3;
+      }
+      .message.error {
+        background: rgba(239, 68, 68, 0.08);
+        border-color: rgba(239, 68, 68, 0.2);
+        color: #b91c1c;
+      }
+      table {
+        width: 100%;
+        border-collapse: collapse;
+      }
+      th,
+      td {
+        text-align: left;
+        padding: 0.75rem 0.5rem;
+        border-bottom: 1px solid rgba(148, 163, 184, 0.25);
+      }
+      .hidden {
+        display: none !important;
+      }
+      @media (max-width: 768px) {
+        header {
+          padding: 2rem 1.75rem 1.5rem;
+        }
+        main {
+          padding: 2rem 1.75rem 2.5rem;
+        }
+        section {
+          padding: 1.5rem;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="page">
+      <header>
+        <h1>Algorithm Guessr</h1>
+        <p>随机挑战 Codeforces 题目，识别算法标签，赢取积分！</p>
+      </header>
+      <main>
+        <section id="auth-section">
+          <h2>账户</h2>
+          <div class="grid-two">
+            <form id="login-form">
+              <h3>登录</h3>
+              <label>用户名<input name="username" autocomplete="username" required /></label>
+              <label>密码<input type="password" name="password" autocomplete="current-password" required /></label>
+              <button type="submit">登录</button>
+              <p id="login-error" class="message error hidden"></p>
+            </form>
+            <form id="register-form">
+              <h3>注册</h3>
+              <label>用户名<input name="username" autocomplete="username" required minlength="3" maxlength="32" /></label>
+              <label>密码<input type="password" name="password" autocomplete="new-password" required minlength="6" maxlength="64" /></label>
+              <button type="submit">注册</button>
+              <p id="register-error" class="message error hidden"></p>
+              <p id="register-closed" class="message hidden">注册暂未开放，请稍后再来或联系管理员。</p>
+            </form>
+          </div>
+        </section>
+
+        <section id="user-section" class="hidden">
+          <div class="grid-two" style="align-items: center;">
+            <div>
+              <h2>你好，<span id="user-name"></span> 👋</h2>
+              <p>当前积分：<strong id="user-score">0</strong></p>
+              <p id="user-status"></p>
+            </div>
+            <div style="justify-self: end; display: flex; gap: 0.75rem;">
+              <button id="logout-btn" class="secondary">退出登录</button>
+              <button id="refresh-problem" class="secondary">刷新题目</button>
+            </div>
+          </div>
+          <div id="admin-panel" class="hidden" style="margin-top: 1.5rem;">
+            <h3>管理员控制台</h3>
+            <div class="grid-two">
+              <form id="admin-register-form">
+                <label>用户名<input name="username" required /></label>
+                <label>密码<input type="password" name="password" required /></label>
+                <button type="submit">后台注册用户</button>
+              </form>
+              <form id="admin-ban-form">
+                <label>用户名<input name="username" required /></label>
+                <div style="display:flex; gap:0.75rem;">
+                  <button type="submit">封禁用户</button>
+                  <button type="button" id="admin-unban-btn" class="secondary">解封用户</button>
+                </div>
+              </form>
+            </div>
+            <div style="margin-top:1rem; display:flex; gap:1rem; align-items:center;">
+              <button id="toggle-registration" class="secondary"></button>
+              <span id="registration-state"></span>
+            </div>
+            <div style="margin-top:1.5rem;">
+              <h4>用户列表</h4>
+              <table>
+                <thead>
+                  <tr><th>用户名</th><th>积分</th><th>角色</th><th>状态</th></tr>
+                </thead>
+                <tbody id="admin-user-table"></tbody>
+              </table>
+            </div>
+          </div>
+        </section>
+
+        <section id="problem-section" class="hidden problem-card">
+          <header>
+            <div style="display:flex; justify-content: space-between; align-items: baseline; gap: 1rem;">
+              <h2 id="problem-title">题目</h2>
+              <a id="problem-link" href="#" target="_blank" rel="noopener" style="font-size:0.9rem;">在 Codeforces 查看</a>
+            </div>
+            <div class="problem-meta">
+              <span>难度：<strong id="problem-difficulty">-</strong></span>
+              <span>来源：Codeforces</span>
+            </div>
+          </header>
+          <div id="problem-statement" class="problem-statement">请先选择难度范围并加载题目。</div>
+          <div class="grid-two">
+            <form id="difficulty-form" class="problem-controls">
+              <label>最低难度（含）<input type="number" id="min-difficulty" min="800" max="3500" step="100" value="800" /></label>
+              <label>最高难度（含）<input type="number" id="max-difficulty" min="800" max="3500" step="100" value="1600" /></label>
+              <button type="submit">获取随机题目</button>
+            </form>
+            <div>
+              <h3>请选择算法标签</h3>
+              <div id="tag-options" class="tag-options"></div>
+              <div style="margin-top:1rem; display:flex; gap:0.75rem; align-items:center;">
+                <button id="submit-attempt" disabled>提交答案</button>
+                <span id="attempt-message" class="message hidden"></span>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section id="leaderboard-section">
+          <h2>排行榜</h2>
+          <table>
+            <thead>
+              <tr><th>#</th><th>用户</th><th>积分</th></tr>
+            </thead>
+            <tbody id="leaderboard-body"></tbody>
+          </table>
+        </section>
+      </main>
+    </div>
+    <script>
+      const state = {
+        token: localStorage.getItem('alg_guessr_token'),
+        user: null,
+        problem: null,
+        registrationOpen: true,
+        selectedTags: new Set(),
+      };
+
+      function setMessage(el, text, type = '') {
+        if (!el) return;
+        el.textContent = text;
+        el.classList.remove('hidden', 'error');
+        if (type === 'error') {
+          el.classList.add('error');
+        }
+        if (!text) {
+          el.classList.add('hidden');
+        }
+      }
+
+      async function api(path, options = {}) {
+        const headers = { ...(options.headers || {}) };
+        const hasBody = options.body !== undefined && !(options.body instanceof FormData);
+        if (hasBody && !headers['Content-Type']) {
+          headers['Content-Type'] = 'application/json';
+        }
+        if (state.token) {
+          headers['Authorization'] = 'Bearer ' + state.token;
+        }
+        const response = await fetch(path, { ...options, headers });
+        if (response.status === 204) return null;
+        const data = await response.json().catch(() => ({}));
+        if (!response.ok) {
+          throw new Error(data?.error || '请求失败');
+        }
+        return data;
+      }
+
+      function updateAuthUI() {
+        const authSection = document.getElementById('auth-section');
+        const userSection = document.getElementById('user-section');
+        const problemSection = document.getElementById('problem-section');
+        if (state.user) {
+          authSection.classList.add('hidden');
+          userSection.classList.remove('hidden');
+          problemSection.classList.remove('hidden');
+          document.getElementById('user-name').textContent = state.user.username;
+          document.getElementById('user-score').textContent = state.user.score;
+          document.getElementById('user-status').textContent = state.user.is_banned ? '已封禁' : '正常';
+          document.getElementById('logout-btn').disabled = false;
+          if (state.user.role === 'admin') {
+            loadAdminData();
+            document.getElementById('admin-panel').classList.remove('hidden');
+          } else {
+            document.getElementById('admin-panel').classList.add('hidden');
+          }
+        } else {
+          authSection.classList.remove('hidden');
+          userSection.classList.add('hidden');
+          problemSection.classList.add('hidden');
+          document.getElementById('admin-panel').classList.add('hidden');
+          document.getElementById('tag-options').innerHTML = '';
+          document.getElementById('problem-statement').textContent = '请先登录后获取题目。';
+          state.problem = null;
+          state.selectedTags.clear();
+        }
+      }
+
+      function updateRegistrationUI() {
+        const registerForm = document.getElementById('register-form');
+        const closedMessage = document.getElementById('register-closed');
+        if (state.registrationOpen) {
+          registerForm.classList.remove('hidden');
+          closedMessage.classList.add('hidden');
+        } else {
+          registerForm.classList.add('hidden');
+          closedMessage.classList.remove('hidden');
+        }
+      }
+
+      function renderTagOptions(options = []) {
+        const container = document.getElementById('tag-options');
+        container.innerHTML = '';
+        state.selectedTags.clear();
+        options.forEach((tag) => {
+          const btn = document.createElement('button');
+          btn.type = 'button';
+          btn.className = 'tag-option';
+          btn.textContent = tag;
+          btn.dataset.tag = tag;
+          btn.addEventListener('click', () => {
+            if (btn.classList.contains('correct') || btn.classList.contains('incorrect')) return;
+            if (state.selectedTags.has(tag)) {
+              state.selectedTags.delete(tag);
+              btn.classList.remove('selected');
+            } else {
+              state.selectedTags.add(tag);
+              btn.classList.add('selected');
+            }
+            document.getElementById('submit-attempt').disabled = state.selectedTags.size === 0;
+          });
+          container.appendChild(btn);
+        });
+        document.getElementById('submit-attempt').disabled = true;
+        setMessage(document.getElementById('attempt-message'), '');
+      }
+
+      function markAttemptResult(correctTags, correct) {
+        const container = document.getElementById('tag-options');
+        const buttons = container.querySelectorAll('.tag-option');
+        const correctSet = new Set(correctTags || []);
+        buttons.forEach((btn) => {
+          const tag = btn.dataset.tag;
+          if (correctSet.has(tag)) {
+            btn.classList.add('correct');
+          }
+          if (state.selectedTags.has(tag) && !correctSet.has(tag)) {
+            btn.classList.add('incorrect');
+          }
+          btn.classList.remove('selected');
+        });
+        document.getElementById('submit-attempt').disabled = true;
+        setMessage(
+          document.getElementById('attempt-message'),
+          correct ? '回答正确！积分 +1' : '回答错误，正确标签已标记。积分 -1',
+          correct ? '' : 'error'
+        );
+      }
+
+      async function loadLeaderboard() {
+        try {
+          const data = await api('/api/leaderboard', { method: 'GET', headers: {} });
+          const tbody = document.getElementById('leaderboard-body');
+          tbody.innerHTML = '';
+          data.leaderboard.forEach((entry, index) => {
+            const tr = document.createElement('tr');
+
+            const rankCell = document.createElement('td');
+            rankCell.textContent = String(index + 1);
+            tr.appendChild(rankCell);
+
+            const nameCell = document.createElement('td');
+            nameCell.textContent = entry.username;
+            tr.appendChild(nameCell);
+
+            const scoreCell = document.createElement('td');
+            scoreCell.textContent = String(entry.score);
+            tr.appendChild(scoreCell);
+
+            tbody.appendChild(tr);
+          });
+        } catch (err) {
+          console.error(err);
+        }
+      }
+
+      async function loadProblem(range) {
+        if (!state.user) return;
+        document.getElementById('submit-attempt').disabled = true;
+        setMessage(document.getElementById('attempt-message'), '加载中...');
+        try {
+          const params = new URLSearchParams(range).toString();
+          const data = await api('/api/problem?' + params, { method: 'GET', headers: {} });
+          state.problem = data.problem;
+          document.getElementById('problem-title').textContent = data.problem.title;
+          document.getElementById('problem-difficulty').textContent = data.problem.difficulty ?? '未知';
+          document.getElementById('problem-link').href = data.problem.url;
+          document.getElementById('problem-statement').innerHTML = data.problem.statement || '暂时无法获取题面，请点击链接查看原题。';
+          renderTagOptions(data.problem.availableTags || []);
+          setMessage(document.getElementById('attempt-message'), '请选择你认为正确的算法标签');
+        } catch (err) {
+          console.error(err);
+          setMessage(document.getElementById('attempt-message'), err.message || '题目加载失败', 'error');
+        }
+      }
+
+      async function fetchStatus() {
+        try {
+          const data = await api('/api/status', { method: 'GET', headers: {} });
+          state.registrationOpen = data.registrationOpen;
+          updateRegistrationUI();
+        } catch (err) {
+          console.error(err);
+        }
+      }
+
+      async function fetchProfile() {
+        if (!state.token) {
+          state.user = null;
+          updateAuthUI();
+          return;
+        }
+        try {
+          const data = await api('/api/me', { method: 'GET', headers: {} });
+          state.user = data.user;
+          state.registrationOpen = data.registrationOpen;
+          updateAuthUI();
+          updateRegistrationUI();
+        } catch (err) {
+          console.warn('profile fetch failed', err);
+          state.token = null;
+          localStorage.removeItem('alg_guessr_token');
+          state.user = null;
+          updateAuthUI();
+        }
+      }
+
+      async function loadAdminData() {
+        if (!state.user || state.user.role !== 'admin') return;
+        try {
+          const data = await api('/api/admin/users', { method: 'GET', headers: {} });
+          const tbody = document.getElementById('admin-user-table');
+          tbody.innerHTML = '';
+          data.users.forEach((user) => {
+            const tr = document.createElement('tr');
+
+            const nameCell = document.createElement('td');
+            nameCell.textContent = user.username;
+            tr.appendChild(nameCell);
+
+            const scoreCell = document.createElement('td');
+            scoreCell.textContent = String(user.score);
+            tr.appendChild(scoreCell);
+
+            const roleCell = document.createElement('td');
+            roleCell.textContent = user.role;
+            tr.appendChild(roleCell);
+
+            const statusCell = document.createElement('td');
+            statusCell.textContent = user.is_banned ? '封禁' : '正常';
+            tr.appendChild(statusCell);
+
+            tbody.appendChild(tr);
+          });
+          state.registrationOpen = data.registrationOpen;
+          document.getElementById('registration-state').textContent = state.registrationOpen ? '当前注册已开放' : '当前注册已关闭';
+          document.getElementById('toggle-registration').textContent = state.registrationOpen ? '关闭注册入口' : '开放注册入口';
+        } catch (err) {
+          console.error(err);
+        }
+      }
+
+      document.getElementById('login-form').addEventListener('submit', async (event) => {
+        event.preventDefault();
+        const form = event.currentTarget;
+        const data = Object.fromEntries(new FormData(form));
+        setMessage(document.getElementById('login-error'), '');
+        try {
+          const result = await api('/api/login', { method: 'POST', body: JSON.stringify(data) });
+          state.token = result.token;
+          localStorage.setItem('alg_guessr_token', state.token);
+          await fetchProfile();
+          await loadLeaderboard();
+        } catch (err) {
+          setMessage(document.getElementById('login-error'), err.message || '登录失败', 'error');
+        }
+      });
+
+      document.getElementById('register-form').addEventListener('submit', async (event) => {
+        event.preventDefault();
+        const form = event.currentTarget;
+        const data = Object.fromEntries(new FormData(form));
+        setMessage(document.getElementById('register-error'), '');
+        try {
+          await api('/api/register', { method: 'POST', body: JSON.stringify(data) });
+          setMessage(document.getElementById('register-error'), '注册成功，请登录。');
+          form.reset();
+        } catch (err) {
+          setMessage(document.getElementById('register-error'), err.message || '注册失败', 'error');
+        }
+      });
+
+      document.getElementById('logout-btn').addEventListener('click', () => {
+        state.token = null;
+        state.user = null;
+        localStorage.removeItem('alg_guessr_token');
+        updateAuthUI();
+      });
+
+      document.getElementById('refresh-problem').addEventListener('click', () => {
+        const min = document.getElementById('min-difficulty').value;
+        const max = document.getElementById('max-difficulty').value;
+        loadProblem({ min, max });
+      });
+
+      document.getElementById('difficulty-form').addEventListener('submit', (event) => {
+        event.preventDefault();
+        const min = document.getElementById('min-difficulty').value;
+        const max = document.getElementById('max-difficulty').value;
+        loadProblem({ min, max });
+      });
+
+      document.getElementById('submit-attempt').addEventListener('click', async () => {
+        if (!state.problem || state.selectedTags.size === 0) return;
+        const payload = {
+          problemId: state.problem.id,
+          selectedTags: Array.from(state.selectedTags),
+        };
+        try {
+          const result = await api('/api/attempt', { method: 'POST', body: JSON.stringify(payload) });
+          state.user.score = result.score;
+          document.getElementById('user-score').textContent = state.user.score;
+          markAttemptResult(result.correctTags, result.correct);
+          loadLeaderboard();
+        } catch (err) {
+          setMessage(document.getElementById('attempt-message'), err.message || '提交失败', 'error');
+        }
+      });
+
+      document.getElementById('toggle-registration').addEventListener('click', async () => {
+        if (!state.user || state.user.role !== 'admin') return;
+        try {
+          const data = await api('/api/admin/registration-toggle', {
+            method: 'POST',
+            body: JSON.stringify({ open: !state.registrationOpen }),
+          });
+          state.registrationOpen = data.registrationOpen;
+          document.getElementById('registration-state').textContent = state.registrationOpen ? '当前注册已开放' : '当前注册已关闭';
+          document.getElementById('toggle-registration').textContent = state.registrationOpen ? '关闭注册入口' : '开放注册入口';
+          updateRegistrationUI();
+        } catch (err) {
+          console.error(err);
+        }
+      });
+
+      document.getElementById('admin-register-form').addEventListener('submit', async (event) => {
+        event.preventDefault();
+        if (!state.user || state.user.role !== 'admin') return;
+        const data = Object.fromEntries(new FormData(event.currentTarget));
+        try {
+          await api('/api/admin/register', { method: 'POST', body: JSON.stringify(data) });
+          event.currentTarget.reset();
+          loadAdminData();
+        } catch (err) {
+          alert(err.message || '后台注册失败');
+        }
+      });
+
+      document.getElementById('admin-ban-form').addEventListener('submit', async (event) => {
+        event.preventDefault();
+        if (!state.user || state.user.role !== 'admin') return;
+        const data = Object.fromEntries(new FormData(event.currentTarget));
+        try {
+          await api('/api/admin/ban', { method: 'POST', body: JSON.stringify(data) });
+          loadAdminData();
+        } catch (err) {
+          alert(err.message || '封禁失败');
+        }
+      });
+
+      document.getElementById('admin-unban-btn').addEventListener('click', async () => {
+        if (!state.user || state.user.role !== 'admin') return;
+        const username = new FormData(document.getElementById('admin-ban-form')).get('username');
+        if (!username) return;
+        try {
+          await api('/api/admin/unban', { method: 'POST', body: JSON.stringify({ username }) });
+          loadAdminData();
+        } catch (err) {
+          alert(err.message || '解封失败');
+        }
+      });
+
+      fetchStatus();
+      fetchProfile();
+      loadLeaderboard();
+    </script>
+  </body>
+</html>`;
+}

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1,0 +1,651 @@
+import { Router } from 'itty-router';
+import { renderApp } from './ui/index';
+
+interface Env {
+  DB: D1Database;
+  PROBLEM_CACHE: KVNamespace;
+  JWT_SECRET: string;
+}
+
+interface UserRow {
+  id: number;
+  username: string;
+  password_hash: string;
+  salt: string;
+  role: 'user' | 'admin';
+  is_banned: number;
+  score: number;
+  created_at: string;
+  updated_at: string;
+}
+
+interface ProblemMetadata {
+  id: string;
+  title: string;
+  difficulty?: number;
+  statement?: string;
+  tags: string[];
+  url: string;
+  fetchedAt: number;
+}
+
+const AVAILABLE_TAGS = [
+  'dp',
+  'greedy',
+  'implementation',
+  'math',
+  'brute force',
+  'data structures',
+  'graphs',
+  'constructive algorithms',
+  'sortings',
+  'binary search',
+  'combinatorics',
+  'number theory',
+  'trees',
+  'geometry',
+  'shortest paths',
+  'strings',
+  'dfs and similar',
+  'two pointers',
+  'bitmasks',
+  'probabilities',
+  'hashing',
+  'games',
+  'flows',
+  'matrices',
+  'meet-in-the-middle',
+  'graph matchings',
+  'ternary search',
+  'dsu',
+  'divide and conquer',
+  'expression parsing',
+  'schedules',
+  'scc',
+  'fft',
+  'interactive',
+  '2-sat',
+  'chinese remainder theorem',
+];
+
+const router = Router();
+
+router.options('*', () =>
+  new Response(null, {
+    status: 204,
+    headers: buildCorsHeaders(),
+  }),
+);
+
+router.get('/', () =>
+  new Response(renderApp(), {
+    headers: {
+      'Content-Type': 'text/html; charset=utf-8',
+    },
+  }),
+);
+
+router.get('/api/status', async (request, env: Env) => {
+  const registrationOpen = await getRegistrationState(env);
+  return json({ registrationOpen });
+});
+
+router.post('/api/register', async (request, env: Env) => {
+  const { username, password } = await readJson(request);
+  if (!username || !password) {
+    return error('用户名和密码不能为空', 400);
+  }
+  if (typeof username !== 'string' || typeof password !== 'string') {
+    return error('参数格式不正确', 400);
+  }
+  const trimmedUsername = username.trim();
+  if (trimmedUsername.length < 3 || trimmedUsername.length > 32) {
+    return error('用户名长度需在 3-32 之间', 400);
+  }
+  if (password.length < 6 || password.length > 64) {
+    return error('密码长度需在 6-64 之间', 400);
+  }
+
+  const userCountRow = await env.DB.prepare('SELECT COUNT(*) as count FROM users').first<{ count: number }>();
+  const registrationOpen = await getRegistrationState(env);
+  if (userCountRow && userCountRow.count > 0 && !registrationOpen) {
+    return error('注册暂未开放', 403);
+  }
+
+  const { hash, salt } = await hashPassword(password);
+  const role = userCountRow && userCountRow.count === 0 ? 'admin' : 'user';
+  try {
+    await env.DB.prepare(
+      `INSERT INTO users (username, password_hash, salt, role)
+       VALUES (?, ?, ?, ?)`,
+    )
+      .bind(trimmedUsername, hash, salt, role)
+      .run();
+  } catch (err) {
+    return error('用户名已存在', 409);
+  }
+
+  return json({ success: true, role });
+});
+
+router.post('/api/login', async (request, env: Env) => {
+  const { username, password } = await readJson(request);
+  if (!username || !password) {
+    return error('用户名和密码不能为空', 400);
+  }
+  const row = await env.DB.prepare('SELECT * FROM users WHERE username = ?').bind(username).first<UserRow>();
+  if (!row) {
+    return error('用户名或密码错误', 401);
+  }
+  if (row.is_banned) {
+    return error('账号已被封禁，请联系管理员', 403);
+  }
+  const valid = await verifyPassword(password, row.password_hash, row.salt);
+  if (!valid) {
+    return error('用户名或密码错误', 401);
+  }
+  const token = await createToken(env, {
+    sub: row.id,
+    username: row.username,
+    role: row.role,
+  });
+  return json({ token });
+});
+
+router.get('/api/me', withAuth(async (request, env, user) => {
+  const registrationOpen = await getRegistrationState(env);
+  return json({
+    user: {
+      id: user.id,
+      username: user.username,
+      role: user.role,
+      score: user.score,
+      is_banned: user.is_banned === 1,
+    },
+    registrationOpen,
+  });
+}));
+
+router.get('/api/problem', withAuth(async (request, env, user) => {
+  if (user.is_banned) {
+    return error('账号已被封禁', 403);
+  }
+  const url = new URL(request.url);
+  const min = Number(url.searchParams.get('min') || '800');
+  const max = Number(url.searchParams.get('max') || '1600');
+  if (Number.isNaN(min) || Number.isNaN(max) || min < 800 || max > 3500 || min > max) {
+    return error('难度范围不合法', 400);
+  }
+  const problem = await fetchRandomProblem(env, min, max);
+  if (!problem) {
+    return error('无法获取题目，请稍后重试', 502);
+  }
+  return json({
+    problem: {
+      id: problem.id,
+      title: problem.title,
+      difficulty: problem.difficulty,
+      statement: problem.statement,
+      url: problem.url,
+      availableTags: AVAILABLE_TAGS,
+    },
+  });
+}));
+
+router.post('/api/attempt', withAuth(async (request, env, user) => {
+  if (user.is_banned) {
+    return error('账号已被封禁', 403);
+  }
+  const { problemId, selectedTags } = await readJson(request);
+  if (!problemId || !Array.isArray(selectedTags)) {
+    return error('参数不正确', 400);
+  }
+  const meta = await env.PROBLEM_CACHE.get<ProblemMetadata>(problemCacheKey(problemId), 'json');
+  if (!meta) {
+    return error('题目已过期，请重新获取', 410);
+  }
+  const chosen = new Set<string>(selectedTags.map((tag: string) => String(tag)));
+  const correctSet = new Set(meta.tags);
+  let correct = true;
+  if (chosen.size !== correctSet.size) {
+    correct = false;
+  } else {
+    for (const tag of chosen) {
+      if (!correctSet.has(tag)) {
+        correct = false;
+        break;
+      }
+    }
+  }
+  const delta = correct ? 1 : -1;
+  await env.DB.batch([
+    env.DB.prepare(
+      `UPDATE users
+       SET score = score + ?, updated_at = CURRENT_TIMESTAMP
+       WHERE id = ?`,
+    ).bind(delta, user.id),
+    env.DB.prepare(
+      `INSERT INTO problem_attempts (user_id, problem_id, correct, selected_tags, correct_tags)
+       VALUES (?, ?, ?, ?, ?)`
+    ).bind(user.id, problemId, correct ? 1 : 0, JSON.stringify([...chosen]), JSON.stringify([...correctSet])),
+  ]);
+  const updated = await env.DB.prepare('SELECT score FROM users WHERE id = ?').bind(user.id).first<{ score: number }>();
+  return json({
+    correct,
+    correctTags: [...correctSet],
+    score: updated?.score ?? user.score + delta,
+  });
+}));
+
+router.get('/api/leaderboard', async (request, env: Env) => {
+  const results = await env.DB.prepare(
+    `SELECT username, score
+     FROM users
+     WHERE is_banned = 0
+     ORDER BY score DESC, username ASC
+     LIMIT 20`,
+  ).all<{ username: string; score: number }>();
+  return json({ leaderboard: results.results ?? [] });
+});
+
+router.get('/api/admin/users', withAdmin(async (request, env) => {
+  const users = await env.DB.prepare(
+    `SELECT id, username, role, is_banned, score
+     FROM users
+     ORDER BY created_at ASC`
+  ).all<UserRow>();
+  const registrationOpen = await getRegistrationState(env);
+  return json({
+    users: (users.results ?? []).map((u) => ({
+      id: u.id,
+      username: u.username,
+      role: u.role,
+      is_banned: u.is_banned === 1,
+      score: u.score,
+    })),
+    registrationOpen,
+  });
+}));
+
+router.post('/api/admin/register', withAdmin(async (request, env) => {
+  const { username, password } = await readJson(request);
+  if (!username || !password) {
+    return error('请输入用户名和密码', 400);
+  }
+  const trimmedUsername = String(username).trim();
+  if (trimmedUsername.length < 3) {
+    return error('用户名过短', 400);
+  }
+  const { hash, salt } = await hashPassword(String(password));
+  try {
+    await env.DB.prepare(
+      `INSERT INTO users (username, password_hash, salt, role)
+       VALUES (?, ?, ?, 'user')`
+    ).bind(trimmedUsername, hash, salt).run();
+  } catch (err) {
+    return error('用户名已存在', 409);
+  }
+  return json({ success: true });
+}));
+
+router.post('/api/admin/ban', withAdmin(async (request, env) => {
+  const { username } = await readJson(request);
+  if (!username) {
+    return error('请输入用户名', 400);
+  }
+  await env.DB.prepare(
+    `UPDATE users
+     SET is_banned = 1, updated_at = CURRENT_TIMESTAMP
+     WHERE username = ? AND role != 'admin'`
+  ).bind(username).run();
+  return json({ success: true });
+}));
+
+router.post('/api/admin/unban', withAdmin(async (request, env) => {
+  const { username } = await readJson(request);
+  if (!username) {
+    return error('请输入用户名', 400);
+  }
+  await env.DB.prepare(
+    `UPDATE users
+     SET is_banned = 0, updated_at = CURRENT_TIMESTAMP
+     WHERE username = ?`
+  ).bind(username).run();
+  return json({ success: true });
+}));
+
+router.post('/api/admin/registration-toggle', withAdmin(async (request, env) => {
+  const { open } = await readJson(request);
+  const value = open ? 'true' : 'false';
+  await env.DB.prepare(
+    `INSERT INTO settings (key, value) VALUES ('registration_open', ?)
+     ON CONFLICT(key) DO UPDATE SET value = excluded.value`,
+  ).bind(value).run();
+  return json({ registrationOpen: open ? true : false });
+}));
+
+router.all('*', () => error('未找到资源', 404));
+
+export default {
+  async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
+    try {
+      const response = await router.handle(request, env, ctx);
+      if (!response) {
+        return error('未找到资源', 404);
+      }
+      return addCors(response);
+    } catch (err) {
+      console.error('Worker error:', err);
+      return addCors(error('服务器内部错误', 500));
+    }
+  },
+};
+
+function buildCorsHeaders(): HeadersInit {
+  return {
+    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Methods': 'GET,POST,OPTIONS',
+    'Access-Control-Allow-Headers': 'Authorization,Content-Type',
+  };
+}
+
+function addCors(response: Response): Response {
+  const headers = new Headers(response.headers);
+  headers.set('Access-Control-Allow-Origin', '*');
+  headers.set('Access-Control-Allow-Methods', 'GET,POST,OPTIONS');
+  headers.set('Access-Control-Allow-Headers', 'Authorization,Content-Type');
+  return new Response(response.body, {
+    status: response.status,
+    headers,
+  });
+}
+
+async function readJson(request: Request): Promise<any> {
+  try {
+    if (request.headers.get('content-type')?.includes('application/json')) {
+      return await request.json();
+    }
+    const text = await request.text();
+    return text ? JSON.parse(text) : {};
+  } catch (err) {
+    return {};
+  }
+}
+
+function json(data: unknown, init: ResponseInit = {}): Response {
+  return new Response(JSON.stringify(data), {
+    ...init,
+    headers: {
+      'Content-Type': 'application/json; charset=utf-8',
+      ...(init.headers || {}),
+    },
+  });
+}
+
+function error(message: string, status = 400): Response {
+  return json({ error: message }, { status });
+}
+
+function problemCacheKey(id: string): string {
+  return `problem:${id}`;
+}
+
+async function getRegistrationState(env: Env): Promise<boolean> {
+  const row = await env.DB.prepare('SELECT value FROM settings WHERE key = ?').bind('registration_open').first<{ value: string }>();
+  if (!row) {
+    await env.DB.prepare('INSERT OR IGNORE INTO settings (key, value) VALUES ("registration_open", "true")').run();
+    return true;
+  }
+  return row.value !== 'false';
+}
+
+async function fetchRandomProblem(env: Env, minDifficulty: number, maxDifficulty: number): Promise<ProblemMetadata | null> {
+  let problemset: any[];
+  try {
+    problemset = await getProblemset(env);
+  } catch (err) {
+    console.warn('Failed to load Codeforces problemset', err);
+    return null;
+  }
+  const filtered = problemset.filter((p) => typeof p.rating === 'number' && p.rating >= minDifficulty && p.rating <= maxDifficulty);
+  if (!filtered.length) {
+    return null;
+  }
+
+  const candidates = [...filtered];
+  while (candidates.length) {
+    const index = Math.floor(Math.random() * candidates.length);
+    const [candidate] = candidates.splice(index, 1);
+    const metadata = await loadProblemMetadata(env, candidate);
+    if (metadata.tags.length > 0) {
+      await env.PROBLEM_CACHE.put(problemCacheKey(metadata.id), JSON.stringify(metadata), { expirationTtl: 3600 });
+      return metadata;
+    }
+  }
+  return null;
+}
+
+async function getProblemset(env: Env): Promise<any[]> {
+  const cacheKey = 'cf:problemset';
+  const cached = (await env.PROBLEM_CACHE.get<{ problems: any[]; fetchedAt: number }>(cacheKey, 'json')) || null;
+  if (cached && Date.now() - cached.fetchedAt < 60 * 60 * 1000) {
+    return cached.problems;
+  }
+  const response = await fetch('https://codeforces.com/api/problemset.problems');
+  if (!response.ok) {
+    throw new Error('Codeforces API error');
+  }
+  const json = await response.json<any>();
+  if (json.status !== 'OK') {
+    throw new Error('Codeforces API returned non-OK status');
+  }
+  await env.PROBLEM_CACHE.put(cacheKey, JSON.stringify({ problems: json.result.problems, fetchedAt: Date.now() }), {
+    expirationTtl: 3600,
+  });
+  return json.result.problems;
+}
+
+async function loadProblemMetadata(env: Env, problem: any): Promise<ProblemMetadata> {
+  const id = `${problem.contestId}-${problem.index}`;
+  const cachedMeta = await env.PROBLEM_CACHE.get<ProblemMetadata>(problemCacheKey(id), 'json');
+  if (cachedMeta) {
+    return cachedMeta;
+  }
+
+  const problemUrl = `https://codeforces.com/contest/${problem.contestId}/problem/${problem.index}`;
+  let statement = '';
+  let tags: string[] = Array.isArray(problem.tags) ? [...problem.tags] : [];
+  let difficulty = problem.rating ?? undefined;
+
+  try {
+    const vjudgeId = `CodeForces-${problem.contestId}${problem.index}`;
+    const response = await fetch(`https://vjudge.net/problem/data/${vjudgeId}`);
+    if (response.ok) {
+      const data = await response.json<any>();
+      if (data && data.description) {
+        statement = sanitizeHtml(data.description);
+      }
+      if (Array.isArray(data.tags)) {
+        tags = data.tags.map((tag: any) => String(tag));
+      }
+      if (typeof data.difficulty === 'number') {
+        difficulty = data.difficulty;
+      }
+    }
+  } catch (err) {
+    console.warn('Failed to fetch VJudge data', err);
+  }
+
+  if (!statement) {
+    try {
+      const cfPage = await fetch(problemUrl);
+      if (cfPage.ok) {
+        const html = await cfPage.text();
+        const extracted = extractStatement(html);
+        statement = extracted || '';
+      }
+    } catch (err) {
+      console.warn('Failed to fetch Codeforces statement', err);
+    }
+  }
+
+  const normalizedTags = Array.from(new Set(tags.length ? tags : problem.tags || [])).map((tag) => String(tag));
+  const intersected = normalizedTags.filter((tag) => AVAILABLE_TAGS.includes(tag));
+  const finalTags = intersected.length ? intersected : [];
+
+  const meta: ProblemMetadata = {
+    id,
+    title: problem.name,
+    difficulty,
+    statement,
+    tags: finalTags,
+    url: problemUrl,
+    fetchedAt: Date.now(),
+  };
+
+  return meta;
+}
+
+function sanitizeHtml(html: string): string {
+  return html
+    .replace(/<script[\s\S]*?<\/script>/gi, '')
+    .replace(/on[a-z]+="[^"]*"/gi, '')
+    .replace(/javascript:/gi, '')
+    .replace(/data:text\/[a-z]+/gi, '');
+}
+
+function extractStatement(html: string): string | null {
+  const match = html.match(/<div class="problem-statement">([\s\S]*?)<\/div>\s*<div class="problem-statement"/i);
+  if (match) {
+    return sanitizeHtml(match[1]);
+  }
+  const fallback = html.match(/<div class="problem-statement">([\s\S]*?)<\/div>/i);
+  return fallback ? sanitizeHtml(fallback[1]) : null;
+}
+
+async function hashPassword(password: string): Promise<{ hash: string; salt: string }>; 
+async function hashPassword(password: string, salt: string): Promise<{ hash: string; salt: string }>;
+async function hashPassword(password: string, salt?: string): Promise<{ hash: string; salt: string }> {
+  const encoder = new TextEncoder();
+  const saltBytes = salt ? base64ToBytes(salt) : crypto.getRandomValues(new Uint8Array(16));
+  const passwordBytes = encoder.encode(password);
+  const data = new Uint8Array(saltBytes.length + passwordBytes.length);
+  data.set(saltBytes);
+  data.set(passwordBytes, saltBytes.length);
+  const digest = await crypto.subtle.digest('SHA-256', data);
+  const hash = bytesToBase64(new Uint8Array(digest));
+  const saltValue = salt || bytesToBase64(saltBytes);
+  return { hash, salt: saltValue };
+}
+
+async function verifyPassword(password: string, hash: string, salt: string): Promise<boolean> {
+  const { hash: computed } = await hashPassword(password, salt);
+  return timingSafeEqual(computed, hash);
+}
+
+function timingSafeEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  let result = 0;
+  for (let i = 0; i < a.length; i++) {
+    result |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  }
+  return result === 0;
+}
+
+function bytesToBase64(bytes: Uint8Array): string {
+  let binary = '';
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+function base64ToBytes(base64: string): Uint8Array {
+  const normalized = base64.replace(/-/g, '+').replace(/_/g, '/');
+  const padded = normalized.padEnd(normalized.length + (4 - (normalized.length % 4)) % 4, '=');
+  const binary = atob(padded);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes;
+}
+
+interface TokenPayload {
+  sub: number;
+  username: string;
+  role: 'user' | 'admin';
+  exp?: number;
+}
+
+async function createToken(env: Env, payload: TokenPayload): Promise<string> {
+  const header = { alg: 'HS256', typ: 'JWT' };
+  const now = Math.floor(Date.now() / 1000);
+  const body = { ...payload, exp: now + 7 * 24 * 60 * 60 };
+  const encoder = new TextEncoder();
+  const headerEncoded = bytesToBase64(encoder.encode(JSON.stringify(header)));
+  const payloadEncoded = bytesToBase64(encoder.encode(JSON.stringify(body)));
+  const toSign = `${headerEncoded}.${payloadEncoded}`;
+  const key = await crypto.subtle.importKey('raw', encoder.encode(env.JWT_SECRET), { name: 'HMAC', hash: 'SHA-256' }, false, ['sign']);
+  const signature = await crypto.subtle.sign('HMAC', key, encoder.encode(toSign));
+  const signatureEncoded = bytesToBase64(new Uint8Array(signature));
+  return `${headerEncoded}.${payloadEncoded}.${signatureEncoded}`;
+}
+
+async function verifyToken(env: Env, token: string): Promise<TokenPayload | null> {
+  const parts = token.split('.');
+  if (parts.length !== 3) return null;
+  const [header, payload, signature] = parts;
+  const encoder = new TextEncoder();
+  const key = await crypto.subtle.importKey('raw', encoder.encode(env.JWT_SECRET), { name: 'HMAC', hash: 'SHA-256' }, false, ['sign']);
+  const data = `${header}.${payload}`;
+  const expected = await crypto.subtle.sign('HMAC', key, encoder.encode(data));
+  const expectedEncoded = bytesToBase64(new Uint8Array(expected));
+  if (!timingSafeEqual(expectedEncoded, signature)) {
+    return null;
+  }
+  try {
+    const decoded = JSON.parse(new TextDecoder().decode(base64ToBytes(payload)));
+    if (decoded.exp && decoded.exp < Math.floor(Date.now() / 1000)) {
+      return null;
+    }
+    return decoded as TokenPayload;
+  } catch (err) {
+    return null;
+  }
+}
+
+function withAuth(handler: (request: Request, env: Env, user: UserRow) => Promise<Response> | Response) {
+  return async (request: Request, env: Env, ctx: ExecutionContext) => {
+    const token = extractToken(request.headers.get('Authorization'));
+    if (!token) {
+      return error('未授权访问', 401);
+    }
+    const payload = await verifyToken(env, token);
+    if (!payload) {
+      return error('登录已失效，请重新登录', 401);
+    }
+    const row = await env.DB.prepare('SELECT * FROM users WHERE id = ?').bind(payload.sub).first<UserRow>();
+    if (!row) {
+      return error('用户不存在', 401);
+    }
+    return handler(request, env, row);
+  };
+}
+
+function withAdmin(handler: (request: Request, env: Env, user: UserRow) => Promise<Response> | Response) {
+  return withAuth(async (request, env, user) => {
+    if (user.role !== 'admin') {
+      return error('需要管理员权限', 403);
+    }
+    return handler(request, env, user);
+  });
+}
+
+function extractToken(header: string | null): string | null {
+  if (!header) return null;
+  const parts = header.split(' ');
+  if (parts.length !== 2) return null;
+  if (parts[0] !== 'Bearer') return null;
+  return parts[1];
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "types": ["@cloudflare/workers-types"],
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,0 +1,17 @@
+name = "algorithm-guessr"
+main = "src/worker.ts"
+compatibility_date = "2024-05-12"
+compatibility_flags = ["nodejs_compat"]
+
+[vars]
+JWT_SECRET = "change-me-in-production"
+
+[[kv_namespaces]]
+binding = "PROBLEM_CACHE"
+id = "" # 填入实际 KV 命名空间 ID
+preview_id = ""
+
+[[d1_databases]]
+binding = "DB"
+database_name = "algorithm_guessr_db"
+database_id = "" # 填入实际数据库 ID


### PR DESCRIPTION
## Summary
- replace the leaderboard row template literal with explicit DOM cell creation to avoid esbuild parsing errors
- render the admin user list by appending table cells to eliminate the remaining esbuild parsing failure
- pull in the upstream README note about the Codespaces environment taking roughly 10 minutes to provision

## Testing
- not run (wrangler dev requires valid Cloudflare bindings)

------
https://chatgpt.com/codex/tasks/task_b_68e5ceb47dd883308281be5b4241ae21